### PR TITLE
Implement AI training viewer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,11 +4,12 @@ import './assets/css/CardGame.css';
 import React, { useState, useEffect } from "react";
 import StarBackground from './components/Background/StarBackground.js';
 import HuangjunGame from './components/Huangjun/HuangjunGame';
+import TrainingPage from './components/Huangjun/TrainingPage';
 import { connect } from 'react-redux';
 import { incrementCounter } from './actions/counter.actions.js'
 
 function App({ incrementCounter }) {
-  const [showGame, setShowGame] = useState(false);
+  const [page, setPage] = useState('menu');
 
   useEffect(() => {
     const clickHandler = e => {
@@ -25,22 +26,31 @@ function App({ incrementCounter }) {
   return (
     <div className="relative min-h-screen w-full bg-black">
       <StarBackground/>
-      {!showGame ? (
+      {page === 'menu' && (
         <div className="absolute inset-0 flex flex-col items-center justify-center z-10">
           <div className="bg-gray-900 bg-opacity-80 rounded-2xl shadow-2xl p-10 flex flex-col items-center gap-8 border border-gray-700">
             <h1 className="text-4xl font-bold text-white mb-2 tracking-wide">Proteus Nebule</h1>
             <h2 className="text-xl text-gray-300 mb-6">Battle Card Game</h2>
             <button
               className="px-8 py-4 bg-blue-600 hover:bg-blue-700 text-white text-xl font-semibold rounded-lg shadow transition-colors duration-150"
-              onClick={() => setShowGame(true)}
+              onClick={() => setPage('game')}
             >
               Play Huangjun
             </button>
-            {/* Add more menu options here if needed */}
+            <button
+              className="px-8 py-4 bg-green-600 hover:bg-green-700 text-white text-xl font-semibold rounded-lg shadow transition-colors duration-150"
+              onClick={() => setPage('training')}
+            >
+              AI Training
+            </button>
           </div>
         </div>
-      ) : (
-        <HuangjunGame onBackToMenu={() => setShowGame(false)} />
+      )}
+      {page === 'game' && (
+        <HuangjunGame onBackToMenu={() => setPage('menu')} />
+      )}
+      {page === 'training' && (
+        <TrainingPage onBackToMenu={() => setPage('menu')} />
       )}
     </div>
   );

--- a/src/components/Huangjun/Board.js
+++ b/src/components/Huangjun/Board.js
@@ -10,7 +10,7 @@ import { minSize, maxSize } from './boardResize';
 const PANEL_WIDTH = 370; // px, panel + margin
 const PANEL_MIN_MARGIN = 24; // px, margin from right
 
-const Board = ({ onBackToMenu }) => {
+const Board = ({ onBackToMenu, autoPlay = false }) => {
   const [useNewBoard, setUseNewBoard] = useState(true);
   const [useNewPieces, setUseNewPieces] = useState(true);
   const [boardSize, setBoardSize] = useState(1000);
@@ -41,7 +41,7 @@ const Board = ({ onBackToMenu }) => {
   }
 
   return (
-    <GameStateProvider>
+    <GameStateProvider autoPlay={autoPlay}>
       <div className="flex w-full h-screen items-start justify-start bg-transparent relative" ref={boardContainerRef}>
         {/* Board on the left */}
         <div className="relative flex-shrink-0" style={{ width: boardSize, height: boardSize }}>

--- a/src/components/Huangjun/TrainingPage.js
+++ b/src/components/Huangjun/TrainingPage.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import Board from './Board';
+
+const TrainingPage = ({ onBackToMenu }) => {
+  const [running, setRunning] = useState(false);
+
+  const startTraining = () => {
+    setRunning(true);
+  };
+
+  return (
+    <div className="flex flex-col items-center min-h-screen pt-8 bg-gradient-to-br from-gray-900 to-black">
+      <div className="flex gap-4 mb-4">
+        <button
+          className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg"
+          onClick={startTraining}
+        >
+          Start Training
+        </button>
+        <button
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
+          onClick={() => {}}
+        >
+          Archive Games
+        </button>
+        <button
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg"
+          onClick={onBackToMenu}
+        >
+          ← Back to Menu
+        </button>
+      </div>
+      {running ? (
+        <div className="flex flex-wrap gap-8 justify-center w-full">
+          <Board autoPlay onBackToMenu={() => {}} />
+        </div>
+      ) : (
+        <div className="text-white mt-6">Click "Start Training" to begin watching AI games.</div>
+      )}
+    </div>
+  );
+};
+
+export default TrainingPage;

--- a/src/components/Huangjun/botLogic.js
+++ b/src/components/Huangjun/botLogic.js
@@ -3,22 +3,22 @@ import { isValidMove, isWithinBounds } from './movementRules';
 import { archerCanSee } from './archerLogic';
 import { getFlippedCoordinates } from './boardUtils';
 
-const findArcherAttacks = (board, archerTargets) => {
+const findArcherAttacks = (board, archerTargets, team) => {
   const archerAttacks = [];
   for (let y = 0; y < 9; y++) {
     for (let x = 0; x < 9; x++) {
       const p = board[y][x];
-      if (p?.team === 'black' && p?.type === 'archer') {
+      if (p?.team === team && p?.type === 'archer') {
         const archerReadyTargets = archerTargets.filter(t =>
           t.from.x === x && t.from.y === y &&
-          t.team === 'black' &&
+          t.team === team &&
           t.readyIn === 0
         );
 
         if (archerReadyTargets.length > 0) {
           for (const target of archerReadyTargets) {
             const targetPiece = board[target.to.y][target.to.x];
-            if (targetPiece && targetPiece.team !== 'black') {
+            if (targetPiece && targetPiece.team !== team) {
               archerAttacks.push({
                 from: { x, y },
                 to: { x: target.to.x, y: target.to.y }
@@ -32,20 +32,20 @@ const findArcherAttacks = (board, archerTargets) => {
   return archerAttacks;
 };
 
-const findValidMoves = (board) => {
+const findValidMoves = (board, team) => {
   const moves = [];
   for (let y = 0; y < 9; y++) {
     for (let x = 0; x < 9; x++) {
       const p = board[y][x];
-      if (p?.team === 'black') {
+      if (p?.team === team) {
         for (let dy = -3; dy <= 3; dy++) {
           for (let dx = -3; dx <= 3; dx++) {
             const to = { x: x + dx, y: y + dy };
-            if (isWithinBounds(to.x, to.y) && isValidMove(board, { x, y }, to, 'black')) {
+            if (isWithinBounds(to.x, to.y) && isValidMove(board, { x, y }, to, team)) {
               // Don't allow archer direct captures
               if (p.type === 'archer') {
                 const targetPiece = board[to.y][to.x];
-                if (targetPiece && targetPiece.team !== 'black') {
+                if (targetPiece && targetPiece.team !== team) {
                   continue;
                 }
               }
@@ -62,32 +62,35 @@ const findValidMoves = (board) => {
 export const runBotMove = ({
   board,
   archerTargets,
-  handleClick
+  handleClick,
+  team = 'black'
 }) => {
   // First check for archer attacks
-  const archerAttacks = findArcherAttacks(board, archerTargets);
+  const archerAttacks = findArcherAttacks(board, archerTargets, team);
   if (archerAttacks.length) {
     const attack = archerAttacks[Math.floor(Math.random() * archerAttacks.length)];
-    const flippedFrom = getFlippedCoordinates(attack.from.x, attack.from.y);
-    const flippedTo = getFlippedCoordinates(attack.to.x, attack.to.y);
-    
+
+    const from = team === 'black' ? getFlippedCoordinates(attack.from.x, attack.from.y) : attack.from;
+    const to = team === 'black' ? getFlippedCoordinates(attack.to.x, attack.to.y) : attack.to;
+
     setTimeout(() => {
-      handleClick(flippedFrom.x, flippedFrom.y);
-      setTimeout(() => handleClick(flippedTo.x, flippedTo.y), 150);
+      handleClick(from.x, from.y);
+      setTimeout(() => handleClick(to.x, to.y), 150);
     }, 300);
     return;
   }
 
   // Otherwise, make a regular move
-  const moves = findValidMoves(board);
+  const moves = findValidMoves(board, team);
   if (moves.length) {
     const move = moves[Math.floor(Math.random() * moves.length)];
-    const flippedFrom = getFlippedCoordinates(move.from.x, move.from.y);
-    const flippedTo = getFlippedCoordinates(move.to.x, move.to.y);
-    
+
+    const from = team === 'black' ? getFlippedCoordinates(move.from.x, move.from.y) : move.from;
+    const to = team === 'black' ? getFlippedCoordinates(move.to.x, move.to.y) : move.to;
+
     setTimeout(() => {
-      handleClick(flippedFrom.x, flippedFrom.y);
-      setTimeout(() => handleClick(flippedTo.x, flippedTo.y), 150);
+      handleClick(from.x, from.y);
+      setTimeout(() => handleClick(to.x, to.y), 150);
     }, 300);
   }
 };

--- a/src/components/Huangjun/gameStateEffects.js
+++ b/src/components/Huangjun/gameStateEffects.js
@@ -23,3 +23,11 @@ export function useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistor
     }
   }, [board, currentTurn, vsBot, winner, moveHistory.length, moveIndex, handleClick, archerTargets]);
 }
+
+export function useAutoPlayEffect({ autoPlay, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick }) {
+  useEffect(() => {
+    if (autoPlay && !winner && moveIndex === moveHistory.length - 1) {
+      runBotMove({ board, archerTargets, handleClick, team: currentTurn });
+    }
+  }, [autoPlay, board, currentTurn, winner, moveHistory.length, moveIndex, handleClick, archerTargets]);
+}


### PR DESCRIPTION
## Summary
- allow navigation to new training page
- add autoplay mode to board and game state provider
- build useAutoPlayEffect for automated play
- make bot logic team-aware
- provide basic TrainingPage component

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9a1233fc8327a9b8ba9cc646d45c