### PR TITLE
Add AI training view

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "server": "node server/index.js"
   },
   "eslintConfig": {
     "extends": [

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const cors = require('cors');
+const fs = require('fs');
+const { spawn } = require('child_process');
+const path = require('path');
+const app = express();
+const PORT = process.env.PORT || 2002;
+
+app.use(cors());
+app.use(express.json());
+
+app.post('/train', (req, res) => {
+  const games = parseInt(req.body.games, 10) || 1;
+  console.log('POST /train received', games);
+  const script = path.join(__dirname, '../train_ai.py');
+  console.log(`spawning python script ${script}`);
+  const process = spawn('python', [script, games], {
+    cwd: path.join(__dirname, '..')
+  });
+
+  process.stdout.on('data', data => {
+    console.log(`train: ${data}`.trim());
+  });
+  process.stderr.on('data', data => {
+    console.error(`train err: ${data}`.trim());
+  });
+
+  process.on('close', code => {
+    console.log(`train script exited with code ${code}`);
+  });
+
+  console.log('training request acknowledged');
+  res.json({ status: 'training started' });
+});
+
+app.get('/games', (req, res) => {
+  const file = path.join(__dirname, '../ai_data/games.json');
+  try {
+    if (fs.existsSync(file)) {
+      const data = JSON.parse(fs.readFileSync(file));
+      res.json(data);
+    } else {
+      res.json([]);
+    }
+  } catch (err) {
+    console.error('read games error', err);
+    res.status(500).json({ error: 'unable to read games' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/src/App.js
+++ b/src/App.js
@@ -4,11 +4,13 @@ import './assets/css/CardGame.css';
 import React, { useState, useEffect } from "react";
 import StarBackground from './components/Background/StarBackground.js';
 import HuangjunGame from './components/Huangjun/HuangjunGame';
+import TrainingPage from './components/Huangjun/TrainingPage';
+import ArchivePage from './components/Huangjun/ArchivePage';
 import { connect } from 'react-redux';
 import { incrementCounter } from './actions/counter.actions.js'
 
 function App({ incrementCounter }) {
-  const [showGame, setShowGame] = useState(false);
+  const [page, setPage] = useState('menu'); // menu | game | training | archive
 
   useEffect(() => {
     const clickHandler = e => {
@@ -24,23 +26,38 @@ function App({ incrementCounter }) {
 
   return (
     <div className="relative min-h-screen w-full bg-black">
-      <StarBackground/>
-      {!showGame ? (
+      <StarBackground />
+      {page === 'menu' && (
         <div className="absolute inset-0 flex flex-col items-center justify-center z-10">
           <div className="bg-gray-900 bg-opacity-80 rounded-2xl shadow-2xl p-10 flex flex-col items-center gap-8 border border-gray-700">
             <h1 className="text-4xl font-bold text-white mb-2 tracking-wide">Proteus Nebule</h1>
             <h2 className="text-xl text-gray-300 mb-6">Battle Card Game</h2>
             <button
               className="px-8 py-4 bg-blue-600 hover:bg-blue-700 text-white text-xl font-semibold rounded-lg shadow transition-colors duration-150"
-              onClick={() => setShowGame(true)}
+              onClick={() => setPage('game')}
             >
               Play Huangjun
             </button>
-            {/* Add more menu options here if needed */}
+            <button
+              className="px-8 py-4 bg-purple-600 hover:bg-purple-700 text-white text-xl font-semibold rounded-lg shadow transition-colors duration-150"
+              onClick={() => setPage('training')}
+            >
+              AI Training
+            </button>
           </div>
         </div>
-      ) : (
-        <HuangjunGame onBackToMenu={() => setShowGame(false)} />
+      )}
+      {page === 'game' && (
+        <HuangjunGame onBackToMenu={() => setPage('menu')} />
+      )}
+      {page === 'training' && (
+        <TrainingPage
+          onBackToMenu={() => setPage('menu')}
+          onShowArchive={() => setPage('archive')}
+        />
+      )}
+      {page === 'archive' && (
+        <ArchivePage onBackToMenu={() => setPage('menu')} />
       )}
     </div>
   );

--- a/src/components/Huangjun/ArchivePage.js
+++ b/src/components/Huangjun/ArchivePage.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const ArchivePage = ({ onBackToMenu }) => (
+  <div className="flex flex-col items-center justify-center w-full p-4 text-white">
+    <button className="mb-4 px-4 py-2 bg-gray-700 rounded" onClick={onBackToMenu}>
+      ← Back
+    </button>
+    <div className="text-xl">Archived games will appear here.</div>
+  </div>
+);
+
+export default ArchivePage;

--- a/src/components/Huangjun/Board.js
+++ b/src/components/Huangjun/Board.js
@@ -10,15 +10,16 @@ import { minSize, maxSize } from './boardResize';
 const PANEL_WIDTH = 370; // px, panel + margin
 const PANEL_MIN_MARGIN = 24; // px, margin from right
 
-const Board = ({ onBackToMenu }) => {
+const Board = ({ onBackToMenu, aiVsAi = false, showPanel = true }) => {
   const [useNewBoard, setUseNewBoard] = useState(true);
   const [useNewPieces, setUseNewPieces] = useState(true);
   const [boardSize, setBoardSize] = useState(1000);
-  const [panelVisible, setPanelVisible] = useState(true);
+  const [panelVisible, setPanelVisible] = useState(showPanel);
   const boardContainerRef = useRef(null);
 
   // Responsive: hide panel if board + panel > window width
   useEffect(() => {
+    if (!showPanel) return;
     function checkPanelVisibility() {
       const windowWidth = window.innerWidth;
       if (boardSize + PANEL_WIDTH + PANEL_MIN_MARGIN > windowWidth) {
@@ -30,10 +31,11 @@ const Board = ({ onBackToMenu }) => {
     checkPanelVisibility();
     window.addEventListener('resize', checkPanelVisibility);
     return () => window.removeEventListener('resize', checkPanelVisibility);
-  }, [boardSize]);
+  }, [boardSize, showPanel]);
 
   // When menu button is clicked, show panel and shrink board if needed
   function handleShowPanel() {
+    if (!showPanel) return;
     const windowWidth = window.innerWidth;
     const maxBoard = windowWidth - PANEL_WIDTH - PANEL_MIN_MARGIN;
     if (boardSize > maxBoard) setBoardSize(maxBoard);
@@ -41,7 +43,7 @@ const Board = ({ onBackToMenu }) => {
   }
 
   return (
-    <GameStateProvider>
+    <GameStateProvider aiVsAi={aiVsAi}>
       <div className="flex w-full h-screen items-start justify-start bg-transparent relative" ref={boardContainerRef}>
         {/* Board on the left */}
         <div className="relative flex-shrink-0" style={{ width: boardSize, height: boardSize }}>
@@ -54,7 +56,7 @@ const Board = ({ onBackToMenu }) => {
           <BoardResizeHandles boardSize={boardSize} setBoardSize={setBoardSize} />
         </div>
         {/* Right panel for controls and move history */}
-        {panelVisible && (
+        {showPanel && panelVisible && (
           <BoardPanel
             onBackToMenu={onBackToMenu}
             useNewBoard={useNewBoard}
@@ -64,7 +66,7 @@ const Board = ({ onBackToMenu }) => {
           />
         )}
         {/* Floating menu button if panel is hidden */}
-        {!panelVisible && (
+        {showPanel && !panelVisible && (
           <FloatingMenuButton onClick={handleShowPanel} />
         )}
       </div>

--- a/src/components/Huangjun/GameStateProvider.js
+++ b/src/components/Huangjun/GameStateProvider.js
@@ -10,9 +10,9 @@ import {
   toggleFlippedFactory,
   clearSelectionState
 } from './gameStateActions';
-import { useArcherReadyEffect, useBotEffect } from './gameStateEffects';
+import { useArcherReadyEffect, useBotEffect, useDualBotEffect } from './gameStateEffects';
 
-const GameStateProvider = ({ children }) => {
+const GameStateProvider = ({ children, aiVsAi = false }) => {
   const [board, setBoard] = useState(createInitialBoard());
   const [selected, setSelected] = useState(null);
   const [currentTurn, setCurrentTurn] = useState('white');
@@ -30,7 +30,8 @@ const GameStateProvider = ({ children }) => {
 
   // Effects
   useArcherReadyEffect(currentTurn, setArcherTargets);
-  useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick: null }); // handleClick set below
+  useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick: null, flipped }); // handleClick set below
+  useDualBotEffect({ enabled: aiVsAi, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick: null, flipped });
 
   // Handlers
   const handleClick = useCallback(
@@ -54,7 +55,8 @@ const GameStateProvider = ({ children }) => {
   );
 
   // Now that handleClick is defined, re-run bot effect with correct handleClick
-  useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick });
+  useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick, flipped });
+  useDualBotEffect({ enabled: aiVsAi, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick, flipped });
 
   const handleUndo = useCallback(
   handleUndoFactory({ moveIndex, setMoveIndex, moveHistory, setBoard, setCurrentTurn, setSelected, setHighlighted, setCaptureTargets }),

--- a/src/components/Huangjun/HuangjunGame.js
+++ b/src/components/Huangjun/HuangjunGame.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import Board from './Board';
 
-const HuangjunGame = ({ onBackToMenu }) => {
+const HuangjunGame = ({ onBackToMenu, aiVsAi = false, showPanel = true }) => {
   return (
     <div className="flex min-h-screen bg-gradient-to-br from-gray-900 to-black items-start justify-start">
-      <Board onBackToMenu={onBackToMenu} />
+      <Board onBackToMenu={onBackToMenu} aiVsAi={aiVsAi} showPanel={showPanel} />
     </div>
   );
 };

--- a/src/components/Huangjun/TrainingPage.js
+++ b/src/components/Huangjun/TrainingPage.js
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import HuangjunGame from './HuangjunGame';
+
+const TrainingPage = ({ onBackToMenu, onShowArchive }) => {
+  const [training, setTraining] = useState(false);
+  const [games, setGames] = useState(1);
+  const [message, setMessage] = useState('');
+
+  async function startTraining() {
+    try {
+      const res = await fetch('http://localhost:2002/train', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ games: parseInt(games, 10) || 1 })
+      });
+      const data = await res.json();
+      setMessage(data.status);
+      setTraining(true);
+    } catch (err) {
+      setMessage('Error starting training');
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center w-full p-4 text-white">
+      <div className="mb-4 space-x-4 flex items-center">
+        <button
+          className="px-4 py-2 bg-gray-700 rounded"
+          onClick={onBackToMenu}
+        >
+          ← Back
+        </button>
+        <input
+          type="number"
+          className="px-2 py-1 w-20 text-black rounded"
+          value={games}
+          onChange={e => setGames(e.target.value)}
+        />
+        <button
+          className="px-4 py-2 bg-blue-600 rounded"
+          onClick={startTraining}
+        >
+          Start Training
+        </button>
+        <button
+          className="px-4 py-2 bg-green-600 rounded"
+          onClick={onShowArchive}
+        >
+          Archived Games
+        </button>
+      </div>
+      {message && <div className="mb-2 text-sm text-gray-300">{message}</div>}
+      {training && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
+          <HuangjunGame aiVsAi={true} showPanel={false} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TrainingPage;

--- a/src/components/Huangjun/botLogic.js
+++ b/src/components/Huangjun/botLogic.js
@@ -3,22 +3,22 @@ import { isValidMove, isWithinBounds } from './movementRules';
 import { archerCanSee } from './archerLogic';
 import { getFlippedCoordinates } from './boardUtils';
 
-const findArcherAttacks = (board, archerTargets) => {
+const findArcherAttacks = (board, archerTargets, team) => {
   const archerAttacks = [];
   for (let y = 0; y < 9; y++) {
     for (let x = 0; x < 9; x++) {
       const p = board[y][x];
-      if (p?.team === 'black' && p?.type === 'archer') {
+      if (p?.team === team && p?.type === 'archer') {
         const archerReadyTargets = archerTargets.filter(t =>
           t.from.x === x && t.from.y === y &&
-          t.team === 'black' &&
+          t.team === team &&
           t.readyIn === 0
         );
 
         if (archerReadyTargets.length > 0) {
           for (const target of archerReadyTargets) {
             const targetPiece = board[target.to.y][target.to.x];
-            if (targetPiece && targetPiece.team !== 'black') {
+            if (targetPiece && targetPiece.team !== team) {
               archerAttacks.push({
                 from: { x, y },
                 to: { x: target.to.x, y: target.to.y }
@@ -32,20 +32,20 @@ const findArcherAttacks = (board, archerTargets) => {
   return archerAttacks;
 };
 
-const findValidMoves = (board) => {
+const findValidMoves = (board, team) => {
   const moves = [];
   for (let y = 0; y < 9; y++) {
     for (let x = 0; x < 9; x++) {
       const p = board[y][x];
-      if (p?.team === 'black') {
+      if (p?.team === team) {
         for (let dy = -3; dy <= 3; dy++) {
           for (let dx = -3; dx <= 3; dx++) {
             const to = { x: x + dx, y: y + dy };
-            if (isWithinBounds(to.x, to.y) && isValidMove(board, { x, y }, to, 'black')) {
+            if (isWithinBounds(to.x, to.y) && isValidMove(board, { x, y }, to, team)) {
               // Don't allow archer direct captures
               if (p.type === 'archer') {
                 const targetPiece = board[to.y][to.x];
-                if (targetPiece && targetPiece.team !== 'black') {
+                if (targetPiece && targetPiece.team !== team) {
                   continue;
                 }
               }
@@ -62,32 +62,42 @@ const findValidMoves = (board) => {
 export const runBotMove = ({
   board,
   archerTargets,
-  handleClick
+  handleClick,
+  team = 'black',
+  flipForBlack = false
 }) => {
   // First check for archer attacks
-  const archerAttacks = findArcherAttacks(board, archerTargets);
+  const archerAttacks = findArcherAttacks(board, archerTargets, team);
   if (archerAttacks.length) {
     const attack = archerAttacks[Math.floor(Math.random() * archerAttacks.length)];
-    const flippedFrom = getFlippedCoordinates(attack.from.x, attack.from.y);
-    const flippedTo = getFlippedCoordinates(attack.to.x, attack.to.y);
-    
+    const from = team === 'black' && flipForBlack
+      ? getFlippedCoordinates(attack.from.x, attack.from.y)
+      : attack.from;
+    const to = team === 'black' && flipForBlack
+      ? getFlippedCoordinates(attack.to.x, attack.to.y)
+      : attack.to;
+
     setTimeout(() => {
-      handleClick(flippedFrom.x, flippedFrom.y);
-      setTimeout(() => handleClick(flippedTo.x, flippedTo.y), 150);
+      handleClick(from.x, from.y);
+      setTimeout(() => handleClick(to.x, to.y), 150);
     }, 300);
     return;
   }
 
   // Otherwise, make a regular move
-  const moves = findValidMoves(board);
+  const moves = findValidMoves(board, team);
   if (moves.length) {
     const move = moves[Math.floor(Math.random() * moves.length)];
-    const flippedFrom = getFlippedCoordinates(move.from.x, move.from.y);
-    const flippedTo = getFlippedCoordinates(move.to.x, move.to.y);
-    
+    const from = team === 'black' && flipForBlack
+      ? getFlippedCoordinates(move.from.x, move.from.y)
+      : move.from;
+    const to = team === 'black' && flipForBlack
+      ? getFlippedCoordinates(move.to.x, move.to.y)
+      : move.to;
+
     setTimeout(() => {
-      handleClick(flippedFrom.x, flippedFrom.y);
-      setTimeout(() => handleClick(flippedTo.x, flippedTo.y), 150);
+      handleClick(from.x, from.y);
+      setTimeout(() => handleClick(to.x, to.y), 150);
     }, 300);
   }
 };

--- a/src/components/Huangjun/gameStateEffects.js
+++ b/src/components/Huangjun/gameStateEffects.js
@@ -16,10 +16,18 @@ export function useArcherReadyEffect(currentTurn, setArcherTargets) {
   }, [currentTurn, setArcherTargets]);
 }
 
-export function useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick }) {
+export function useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick, flipped }) {
   useEffect(() => {
     if (vsBot && currentTurn === 'black' && !winner && moveIndex === moveHistory.length - 1) {
-      runBotMove({ board, archerTargets, handleClick });
+      runBotMove({ board, archerTargets, handleClick, team: 'black', flipForBlack: flipped });
     }
   }, [board, currentTurn, vsBot, winner, moveHistory.length, moveIndex, handleClick, archerTargets]);
+}
+
+export function useDualBotEffect({ enabled, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick, flipped }) {
+  useEffect(() => {
+    if (enabled && handleClick && !winner && moveIndex === moveHistory.length - 1) {
+      runBotMove({ board, archerTargets, handleClick, team: currentTurn, flipForBlack: flipped });
+    }
+  }, [board, currentTurn, enabled, winner, moveHistory.length, moveIndex, handleClick, archerTargets]);
 }

--- a/train_ai.py
+++ b/train_ai.py
@@ -1,0 +1,25 @@
+import sys, json, random, pathlib
+
+num_games = int(sys.argv[1]) if len(sys.argv) > 1 else 1
+root = pathlib.Path(__file__).resolve().parent
+out_dir = root / 'ai_data'
+out_dir.mkdir(exist_ok=True)
+file_path = out_dir / 'games.json'
+
+try:
+    existing = json.load(file_path.open()) if file_path.exists() else []
+except Exception:
+    existing = []
+
+for i in range(num_games):
+    # placeholder game with random winner
+    existing.append({
+        'id': len(existing) + 1,
+        'winner': random.choice(['white', 'black']),
+        'moves': random.randint(20, 60)
+    })
+
+with file_path.open('w') as f:
+    json.dump(existing, f)
+
+print(f"saved {num_games} games")


### PR DESCRIPTION
## Summary
- add dual bot effect and pass to game state provider
- allow hiding panel and AI vs AI mode in board
- allow HuangjunGame to use new options
- create Training and Archive pages
- add menu state to App for navigation
- fix AI training page and add server for batch games
- fix AI vs AI board updates
- use 'python' when spawning the training script
- don't flip bot coordinates unless requested

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9e8b6aac8327908daac9b8f2ee0f