### PR TITLE
Enable dual-bot games and concurrent training

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,10 +11,11 @@ app.use(express.json());
 
 app.post('/train', (req, res) => {
   const games = parseInt(req.body.games, 10) || 1;
-  console.log('POST /train received', games);
+  const repeats = parseInt(req.body.repeats, 10) || 1;
+  console.log('POST /train received', games, repeats);
   const script = path.join(__dirname, '../train_ai.py');
   console.log(`spawning python script ${script}`);
-  const process = spawn('python', [script, games], { cwd: path.join(__dirname, '..') });
+  const process = spawn('python', [script, games, repeats], { cwd: path.join(__dirname, '..') });
 
   process.stdout.on('data', data => {
     console.log(`train: ${data}`.trim());
@@ -43,6 +44,21 @@ app.get('/games', (req, res) => {
   } catch (err) {
     console.error('read games error', err);
     res.status(500).json({ error: 'unable to read games' });
+  }
+});
+
+app.post('/game', (req, res) => {
+  const file = path.join(__dirname, '../ai_data/games.json');
+  const game = req.body;
+  try {
+    const existing = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file)) : [];
+    game.id = existing.length + 1;
+    existing.push(game);
+    fs.writeFileSync(file, JSON.stringify(existing));
+    res.json({ status: 'saved' });
+  } catch (err) {
+    console.error('write game error', err);
+    res.status(500).json({ error: 'unable to save game' });
   }
 });
 

--- a/src/components/Huangjun/GameControls.js
+++ b/src/components/Huangjun/GameControls.js
@@ -42,7 +42,11 @@ const GameControls = () => {
           className="ml-2 px-2 py-1 bg-green-700 text-white rounded"
           onClick={() => {
             console.log('sending training request');
-            fetch('http://localhost:2002/train', { method: 'POST' })
+            fetch('http://localhost:2002/train', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ games: 1, repeats: 1 })
+            })
               .then(res => res.json())
               .then(data => console.log('train response', data))
               .catch(err => console.error('train request error', err));

--- a/src/components/Huangjun/GameStateProvider.js
+++ b/src/components/Huangjun/GameStateProvider.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { GameStateContext } from './GameStateContext';
 import { createInitialBoard } from './initialBoard';
 import { getBoardLabels } from './boardUtils';
@@ -32,6 +32,17 @@ const GameStateProvider = ({ children, aiVsAi = false }) => {
   useArcherReadyEffect(currentTurn, setArcherTargets);
   useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick: null }); // handleClick set below
   useDualBotEffect({ enabled: aiVsAi, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick: null });
+
+  useEffect(() => {
+    if (aiVsAi && winner) {
+      const moves = moveHistory.slice(0, moveIndex + 1).map(m => m.notation);
+      fetch('http://localhost:2002/game', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ winner, moves })
+      }).catch(err => console.error('save game error', err));
+    }
+  }, [aiVsAi, winner, moveHistory, moveIndex]);
 
   // Handlers
   const handleClick = useCallback(

--- a/src/components/Huangjun/TrainingPage.js
+++ b/src/components/Huangjun/TrainingPage.js
@@ -3,7 +3,8 @@ import HuangjunGame from './HuangjunGame';
 
 const TrainingPage = ({ onBackToMenu, onShowArchive }) => {
   const [training, setTraining] = useState(false);
-  const [games, setGames] = useState(1);
+  const [concurrent, setConcurrent] = useState(1);
+  const [rounds, setRounds] = useState(1);
   const [message, setMessage] = useState('');
 
   async function startTraining() {
@@ -11,7 +12,10 @@ const TrainingPage = ({ onBackToMenu, onShowArchive }) => {
       const res = await fetch('http://localhost:2002/train', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ games: parseInt(games, 10) || 1 })
+        body: JSON.stringify({
+          games: parseInt(concurrent, 10) || 1,
+          repeats: parseInt(rounds, 10) || 1
+        })
       });
       const data = await res.json();
       setMessage(data.status);
@@ -30,11 +34,19 @@ const TrainingPage = ({ onBackToMenu, onShowArchive }) => {
         >
           ← Back
         </button>
+        <label className="text-sm">Concurrent</label>
         <input
           type="number"
           className="px-2 py-1 w-20 text-black rounded"
-          value={games}
-          onChange={e => setGames(e.target.value)}
+          value={concurrent}
+          onChange={e => setConcurrent(e.target.value)}
+        />
+        <label className="text-sm">Repeat</label>
+        <input
+          type="number"
+          className="px-2 py-1 w-20 text-black rounded"
+          value={rounds}
+          onChange={e => setRounds(e.target.value)}
         />
         <button
           className="px-4 py-2 bg-blue-600 rounded"
@@ -52,7 +64,9 @@ const TrainingPage = ({ onBackToMenu, onShowArchive }) => {
       {message && <div className="mb-2 text-sm text-gray-300">{message}</div>}
       {training && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
-          <HuangjunGame aiVsAi={true} showPanel={false} />
+          {Array.from({ length: parseInt(concurrent, 10) || 1 }).map((_, i) => (
+            <HuangjunGame key={i} aiVsAi={true} showPanel={false} />
+          ))}
         </div>
       )}
     </div>

--- a/src/components/Huangjun/botLogic.js
+++ b/src/components/Huangjun/botLogic.js
@@ -3,22 +3,22 @@ import { isValidMove, isWithinBounds } from './movementRules';
 import { archerCanSee } from './archerLogic';
 import { getFlippedCoordinates } from './boardUtils';
 
-const findArcherAttacks = (board, archerTargets) => {
+const findArcherAttacks = (board, archerTargets, team) => {
   const archerAttacks = [];
   for (let y = 0; y < 9; y++) {
     for (let x = 0; x < 9; x++) {
       const p = board[y][x];
-      if (p?.team === 'black' && p?.type === 'archer') {
+      if (p?.team === team && p?.type === 'archer') {
         const archerReadyTargets = archerTargets.filter(t =>
           t.from.x === x && t.from.y === y &&
-          t.team === 'black' &&
+          t.team === team &&
           t.readyIn === 0
         );
 
         if (archerReadyTargets.length > 0) {
           for (const target of archerReadyTargets) {
             const targetPiece = board[target.to.y][target.to.x];
-            if (targetPiece && targetPiece.team !== 'black') {
+            if (targetPiece && targetPiece.team !== team) {
               archerAttacks.push({
                 from: { x, y },
                 to: { x: target.to.x, y: target.to.y }
@@ -32,20 +32,20 @@ const findArcherAttacks = (board, archerTargets) => {
   return archerAttacks;
 };
 
-const findValidMoves = (board) => {
+const findValidMoves = (board, team) => {
   const moves = [];
   for (let y = 0; y < 9; y++) {
     for (let x = 0; x < 9; x++) {
       const p = board[y][x];
-      if (p?.team === 'black') {
+      if (p?.team === team) {
         for (let dy = -3; dy <= 3; dy++) {
           for (let dx = -3; dx <= 3; dx++) {
             const to = { x: x + dx, y: y + dy };
-            if (isWithinBounds(to.x, to.y) && isValidMove(board, { x, y }, to, 'black')) {
+            if (isWithinBounds(to.x, to.y) && isValidMove(board, { x, y }, to, team)) {
               // Don't allow archer direct captures
               if (p.type === 'archer') {
                 const targetPiece = board[to.y][to.x];
-                if (targetPiece && targetPiece.team !== 'black') {
+                if (targetPiece && targetPiece.team !== team) {
                   continue;
                 }
               }
@@ -62,14 +62,17 @@ const findValidMoves = (board) => {
 export const runBotMove = ({
   board,
   archerTargets,
-  handleClick
+  handleClick,
+  team
 }) => {
   // First check for archer attacks
-  const archerAttacks = findArcherAttacks(board, archerTargets);
+  const archerAttacks = findArcherAttacks(board, archerTargets, team);
   if (archerAttacks.length) {
     const attack = archerAttacks[Math.floor(Math.random() * archerAttacks.length)];
-    const flippedFrom = getFlippedCoordinates(attack.from.x, attack.from.y);
-    const flippedTo = getFlippedCoordinates(attack.to.x, attack.to.y);
+    const flippedFrom = team === 'black' ?
+      getFlippedCoordinates(attack.from.x, attack.from.y) : attack.from;
+    const flippedTo = team === 'black' ?
+      getFlippedCoordinates(attack.to.x, attack.to.y) : attack.to;
     
     setTimeout(() => {
       handleClick(flippedFrom.x, flippedFrom.y);
@@ -79,11 +82,13 @@ export const runBotMove = ({
   }
 
   // Otherwise, make a regular move
-  const moves = findValidMoves(board);
+  const moves = findValidMoves(board, team);
   if (moves.length) {
     const move = moves[Math.floor(Math.random() * moves.length)];
-    const flippedFrom = getFlippedCoordinates(move.from.x, move.from.y);
-    const flippedTo = getFlippedCoordinates(move.to.x, move.to.y);
+    const flippedFrom = team === 'black' ?
+      getFlippedCoordinates(move.from.x, move.from.y) : move.from;
+    const flippedTo = team === 'black' ?
+      getFlippedCoordinates(move.to.x, move.to.y) : move.to;
     
     setTimeout(() => {
       handleClick(flippedFrom.x, flippedFrom.y);

--- a/src/components/Huangjun/gameStateEffects.js
+++ b/src/components/Huangjun/gameStateEffects.js
@@ -19,7 +19,7 @@ export function useArcherReadyEffect(currentTurn, setArcherTargets) {
 export function useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick }) {
   useEffect(() => {
     if (vsBot && currentTurn === 'black' && !winner && moveIndex === moveHistory.length - 1) {
-      runBotMove({ board, archerTargets, handleClick });
+      runBotMove({ board, archerTargets, handleClick, team: 'black' });
     }
   }, [board, currentTurn, vsBot, winner, moveHistory.length, moveIndex, handleClick, archerTargets]);
 }
@@ -27,7 +27,7 @@ export function useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistor
 export function useDualBotEffect({ enabled, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick }) {
   useEffect(() => {
     if (enabled && handleClick && !winner && moveIndex === moveHistory.length - 1) {
-      runBotMove({ board, archerTargets, handleClick });
+      runBotMove({ board, archerTargets, handleClick, team: currentTurn });
     }
   }, [board, currentTurn, enabled, winner, moveHistory.length, moveIndex, handleClick, archerTargets]);
 }

--- a/train_ai.py
+++ b/train_ai.py
@@ -1,6 +1,9 @@
 import sys, json, random, pathlib
 
+# number of games to generate per batch ("concurrent")
 num_games = int(sys.argv[1]) if len(sys.argv) > 1 else 1
+# number of times to repeat that batch
+num_repeats = int(sys.argv[2]) if len(sys.argv) > 2 else 1
 root = pathlib.Path(__file__).resolve().parent
 out_dir = root / 'ai_data'
 out_dir.mkdir(exist_ok=True)
@@ -11,15 +14,19 @@ try:
 except Exception:
     existing = []
 
-for i in range(num_games):
-    # placeholder game with random winner
-    existing.append({
-        'id': len(existing) + 1,
-        'winner': random.choice(['white', 'black']),
-        'moves': random.randint(20, 60)
-    })
+total = num_games * num_repeats
+
+for _ in range(num_repeats):
+    for _ in range(num_games):
+        move_count = random.randint(20, 60)
+        moves = [f"m{i+1}" for i in range(move_count)]
+        existing.append({
+            'id': len(existing) + 1,
+            'winner': random.choice(['white', 'black']),
+            'moves': moves
+        })
 
 with file_path.open('w') as f:
     json.dump(existing, f)
 
-print(f"saved {num_games} games")
+print(f"saved {total} games")


### PR DESCRIPTION
## Summary
- accept number of concurrent games and repetitions when training
- log played games via new `/game` API
- allow training multiple games at once in the UI
- enhance bot logic to play both teams
- store move histories in `games.json`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddf34f92883278261b50d77b4a8ae