### PR TITLE
Improve bot move stability

### DIFF
--- a/src/components/Huangjun/GameStateProvider.js
+++ b/src/components/Huangjun/GameStateProvider.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { GameStateContext } from './GameStateContext';
 import { createInitialBoard } from './initialBoard';
 import { getBoardLabels } from './boardUtils';
@@ -29,9 +29,11 @@ const GameStateProvider = ({ children, aiVsAi = false }) => {
   const [pendingCharge, setPendingCharge] = useState(null);
 
   // Effects
+  const handleClickRef = useRef(null);
+
   useArcherReadyEffect(currentTurn, setArcherTargets);
-  useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick: null }); // handleClick set below
-  useDualBotEffect({ enabled: aiVsAi, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick: null });
+  useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClickRef });
+  useDualBotEffect({ enabled: aiVsAi, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClickRef });
 
   // Handlers
   const handleClick = useCallback(
@@ -54,9 +56,9 @@ const GameStateProvider = ({ children, aiVsAi = false }) => {
     [board, selected, currentTurn, emperorHits, winner, vsBot, moveHistory, moveIndex, highlighted, captureTargets, flipped, archerTargets, castlingRights, pendingCharge]
   );
 
-  // Now that handleClick is defined, re-run bot effect with correct handleClick
-  useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick });
-  useDualBotEffect({ enabled: aiVsAi, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick });
+  useEffect(() => {
+    handleClickRef.current = handleClick;
+  }, [handleClick]);
 
   const handleUndo = useCallback(
   handleUndoFactory({ moveIndex, setMoveIndex, moveHistory, setBoard, setCurrentTurn, setSelected, setHighlighted, setCaptureTargets }),

--- a/src/components/Huangjun/botLogic.js
+++ b/src/components/Huangjun/botLogic.js
@@ -74,7 +74,7 @@ export const runBotMove = ({
     setTimeout(() => {
       handleClick(flippedFrom.x, flippedFrom.y);
       setTimeout(() => handleClick(flippedTo.x, flippedTo.y), 150);
-    }, 300);
+    }, 3000);
     return;
   }
 
@@ -88,6 +88,6 @@ export const runBotMove = ({
     setTimeout(() => {
       handleClick(flippedFrom.x, flippedFrom.y);
       setTimeout(() => handleClick(flippedTo.x, flippedTo.y), 150);
-    }, 300);
+    }, 3000);
   }
 };

--- a/src/components/Huangjun/gameStateEffects.js
+++ b/src/components/Huangjun/gameStateEffects.js
@@ -16,18 +16,29 @@ export function useArcherReadyEffect(currentTurn, setArcherTargets) {
   }, [currentTurn, setArcherTargets]);
 }
 
-export function useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick }) {
+export function useBotEffect({ vsBot, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClickRef }) {
   useEffect(() => {
-    if (vsBot && currentTurn === 'black' && !winner && moveIndex === moveHistory.length - 1) {
-      runBotMove({ board, archerTargets, handleClick });
+    if (
+      vsBot &&
+      currentTurn === 'black' &&
+      !winner &&
+      moveIndex === moveHistory.length - 1 &&
+      handleClickRef.current
+    ) {
+      runBotMove({ board, archerTargets, handleClick: handleClickRef.current });
     }
-  }, [board, currentTurn, vsBot, winner, moveHistory.length, moveIndex, handleClick, archerTargets]);
+  }, [board, currentTurn, vsBot, winner, moveHistory.length, moveIndex, archerTargets, handleClickRef]);
 }
 
-export function useDualBotEffect({ enabled, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClick }) {
+export function useDualBotEffect({ enabled, currentTurn, winner, moveIndex, moveHistory, board, archerTargets, handleClickRef }) {
   useEffect(() => {
-    if (enabled && handleClick && !winner && moveIndex === moveHistory.length - 1) {
-      runBotMove({ board, archerTargets, handleClick });
+    if (
+      enabled &&
+      handleClickRef.current &&
+      !winner &&
+      moveIndex === moveHistory.length - 1
+    ) {
+      runBotMove({ board, archerTargets, handleClick: handleClickRef.current });
     }
-  }, [board, currentTurn, enabled, winner, moveHistory.length, moveIndex, handleClick, archerTargets]);
+  }, [board, currentTurn, enabled, winner, moveHistory.length, moveIndex, archerTargets, handleClickRef]);
 }


### PR DESCRIPTION
## Summary
- keep bot click handler in a ref so effects aren't retriggered every state update
- trigger bot moves using that ref and wait 3 seconds before moving

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e03829a088327b82bf12b93670006